### PR TITLE
Add pre-calculated Length & Area!

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [SCHEMA.md](./SCHEMA.md) for a description of the database schema.
 The data can be imported with:
 
     osm2pgsql -O flex -S ./postpass.lua INPUT_FILENAME.osm.pbf
+    psql -f views.sql
 
 ## Talk slides  
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ The data can be imported with:
     osm2pgsql -O flex -S ./postpass.lua INPUT_FILENAME.osm.pbf
     psql -f views.sql
 
+This need a version of `osm2pgsql` with at least commit
+[`61ac7152`](https://github.com/osm2pgsql-dev/osm2pgsql/commit/61ac71521d00d1dc401b14e97a810f11dbcf9d26).
+`v2.2.0` does not have this commit.
+
 ## Talk slides  
 
 I presented the software with many examples at the State of the Map and State

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -92,6 +92,8 @@ Models OSM relations.
 
 ## Views
 
+The views are defined in `views.sql`.
+
 ### Combined Views
 
 For many queries, you might want to combine points and polygons. This can inflate queries

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -39,10 +39,14 @@ Contains lines built from OSM relations or ways. The `osm_id` column
 is the actual OSM id of the object, and `osm_type` is either 'W' 
 or 'R'.
 
+`length_m`: the length (in metres) of the line along the spheroid. Can be
+0 in edge cases such as a 2 node way, where both nodes have the same location.
+
     CREATE TABLE postpass_line (
         osm_type character(1) NOT NULL,
         osm_id bigint NOT NULL,
         tags jsonb,
+        length_m double precision,
         geom geometry(MultiLineString,4326)
     );
 
@@ -52,10 +56,14 @@ Contains polygons built from OSM relations or ways. The `osm_id` column
 is the actual OSM id of the object, and `osm_type` is either 'W' 
 or 'R'.
 
+`area_m2`: the area (in square metres) of the area in the spheroid. Can be
+0.
+
     CREATE TABLE postpass_polygon (
         osm_type character(1) NOT NULL,
         osm_id bigint NOT NULL,
         tags jsonb,
+        area_m2 double precision,
         geom geometry(MultiPolygon,4326)
     );
 
@@ -92,30 +100,22 @@ Models OSM relations.
 
 ## Views
 
-The views are defined in `views.sql`.
+The views are defined in `views.sql`. This file should be run after an import.
 
 ### Combined Views
 
 For many queries, you might want to combine points and polygons. This can inflate queries
 through excessive use of UNIONs. Therefore, four views have been created to model all possible
-unions between the three geometry tables:
+unions between the three geometry tables.
 
-    CREATE VIEW postpass_pointlinepolygon AS
-        SELECT * FROM postpass_point
-        UNION ALL SELECT * FROM postpass_line
-        UNION ALL SELECT * FROM postpass_polygon;
+Each view as the same columns: `osm_type`, `osm_id`, `tags`, `geom`,
+`length_m`, `area_m2`. The last 2 are `null` for tables which don't have them
+(they might be 0 anyway).
 
-    CREATE VIEW postpass_pointpolygon AS
-        SELECT * FROM postpass_point
-        UNION ALL SELECT * FROM postpass_polygon;
-
-    CREATE VIEW postpass_pointline AS
-        SELECT * FROM postpass_point
-        UNION ALL SELECT * FROM postpass_line;
-
-    CREATE VIEW postpass_linepolygon AS
-        SELECT * FROM postpass_line
-        UNION ALL SELECT * FROM postpass_polygon;
+ * `postpass_pointlinepolygon`: `_point`, `_line` & `_polygon` tables
+ * `postpass_pointline`: `_point` & `_line` & tables
+ * `postpass_pointpolygon`: `_point` & `_polygon` tables
+ * `postpass_linepolygon`: `_line` & `_polygon` tables
 
 ### Compatibility Views
 

--- a/postpass.lua
+++ b/postpass.lua
@@ -70,13 +70,15 @@ tables.line = osm2pgsql.define_table{
     ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
     columns = {
         { column = 'tags',  type = 'jsonb' },
-        { column = 'geom',  type = 'multilinestring', projection = srid }
+        { column = 'geom',  type = 'multilinestring', projection = srid },
+        { column = "length_m", sql_type = "double precision" }
     },
     indexes = {
 	    { column = { "geom" }, name = "postpass_line_geom_idx", method = "gist" },
 	    { column = { "osm_type", "osm_id" }, name = "postpass_line_osm_type_osm_id_idx", method = "btree" },
 	    { column = { "tags" }, name = "postpass_line_tags", method = "gin" },
 	    { expression = "((tags->>'name'::text))" , name = "postpass_line_name", method = "btree" },
+	    { column = { "length_m" }, name = "postpass_line_length_m", method = "btree" },
 	}
 }
 
@@ -85,7 +87,8 @@ tables.polygon = osm2pgsql.define_table{
     ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
     columns = {
         { column = 'tags',  type = 'jsonb' },
-        { column = 'geom',  type = 'multipolygon', projection = srid }
+        { column = 'geom',  type = 'multipolygon', projection = srid },
+        { column = "area_m2", sql_type = "double precision" }
     },
     indexes = {
 	    { column = { "geom" }, name = "postpass_polygon_geom_idx", method = "gist" },
@@ -94,6 +97,7 @@ tables.polygon = osm2pgsql.define_table{
 
 	    { expression = "((tags->>'name'::text))" , name = "postpass_polygon_name", method = "btree" },
 	    { column = {"geom"}, where = "((tags->>'boundary'::text) = 'administrative'::text)" , name = "postpass_polygon_admin", method = "gist" },
+	    { column = { "area_m2" }, name = "postpass_polygon_area_m2", method = "btree" },
 	}
 }
 
@@ -127,12 +131,14 @@ function osm2pgsql.process_way(object)
     if polygon and object.is_closed then
         tables.polygon:insert({
             tags = object.tags,
-            geom = object:as_polygon()
+            geom = object:as_polygon(),
+            area_m2 = object:as_polygon():spherical_area()
         })
     else
         tables.line:insert({
             tags = object.tags,
-            geom = object:as_linestring()
+            geom = object:as_linestring(),
+            length_m = object:as_linestring():spherical_length()
         })
     end
 end
@@ -157,7 +163,8 @@ function osm2pgsql.process_relation(object)
     if not make_polygon then
         tables.line:insert({
             tags = object.tags,
-            geom = object:as_multilinestring()
+            geom = object:as_multilinestring(),
+            length_m = object:as_multilinestring():spherical_length()
         })
     end
 
@@ -167,13 +174,15 @@ function osm2pgsql.process_relation(object)
         if multi_geometry then
             tables.polygon:insert({
                 tags = object.tags,
-                geom = geom
+                geom = geom,
+                area_m2 = geom:spherical_area()
             })
         else
             for sgeom in geom:geometries() do
                 tables.polygon:insert({
                     tags = object.tags,
-                    geom = sgeom
+                    geom = sgeom,
+                    area_m2 = sgeom:spherical_area()
                 })
             end
         end

--- a/views.sql
+++ b/views.sql
@@ -1,0 +1,159 @@
+-- Combined views
+
+CREATE OR REPLACE VIEW postpass_pointlinepolygon AS
+	SELECT * FROM postpass_point
+	UNION ALL SELECT * FROM postpass_line
+	UNION ALL SELECT * FROM postpass_polygon;
+
+CREATE OR REPLACE VIEW postpass_pointpolygon AS
+	SELECT * FROM postpass_point
+	UNION ALL SELECT * FROM postpass_polygon;
+
+CREATE OR REPLACE VIEW postpass_pointline AS
+	SELECT * FROM postpass_point
+	UNION ALL SELECT * FROM postpass_line;
+
+CREATE OR REPLACE VIEW postpass_linepolygon AS
+	SELECT * FROM postpass_line
+	UNION ALL SELECT * FROM postpass_polygon;
+
+
+-- Compatibility Views for backwards compatibility with postpass 0.1
+
+CREATE OR REPLACE VIEW planet_osm_point AS SELECT
+	osm_id,
+	tags->>'access' AS access,
+	tags->>'addr:housename' AS "addr:housename",
+	tags->>'addr:housenumber' AS "addr:housenumber",
+	tags->>'admin_level' AS admin_level,
+	tags->>'aerialway' AS aerialway,
+	tags->>'aeroway' AS aeroway,
+	tags->>'amenity' AS amenity,
+	tags->>'barrier' AS barrier,
+	tags->>'boundary' AS boundary,
+	tags->>'building' AS building,
+	tags->>'highway' AS highway,
+	tags->>'historic' AS historic,
+	tags->>'junction' AS junction,
+	tags->>'landuse' AS landuse,
+	tags->>'layer' AS layer,
+	tags->>'leisure' AS leisure,
+	tags->>'lock' AS lock,
+	tags->>'man_made' AS man_made,
+	tags->>'military' AS military,
+	tags->>'name' AS name,
+	tags->>'natural' AS "natural",
+	tags->>'oneway' AS oneway,
+	tags->>'place' AS place,
+	tags->>'power' AS power,
+	tags->>'railway' AS railway,
+	tags->>'ref' AS ref,
+	tags->>'religion' AS religion,
+	tags->>'shop' AS shop,
+	tags->>'tourism' AS tourism,
+	tags->>'water' AS water,
+	tags->>'waterway' AS waterway,
+	(SELECT hstore(array_agg(key), array_agg(value)) FROM jsonb_each_text(tags))::hstore AS tags,
+	geom AS way
+	FROM postpass_point;
+
+CREATE OR REPLACE VIEW planet_osm_line AS SELECT
+	CASE WHEN osm_type = 'R' THEN -osm_id ELSE osm_id END as osm_id,
+	tags->>'access' AS access,
+	tags->>'addr:housename' AS "addr:housename",
+	tags->>'addr:housenumber' AS "addr:housenumber",
+	tags->>'addr:interpolation' AS "addr:interpolation",
+	tags->>'admin_level' AS admin_level,
+	tags->>'aerialway' AS aerialway,
+	tags->>'aeroway' AS aeroway,
+	tags->>'amenity' AS amenity,
+	tags->>'barrier' AS barrier,
+	tags->>'bicycle' AS bicycle,
+	tags->>'bridge' AS bridge,
+	tags->>'boundary' AS boundary,
+	tags->>'building' AS building,
+	tags->>'construction' AS construction,
+	tags->>'covered' AS covered,
+	tags->>'foot' AS foot,
+	tags->>'highway' AS highway,
+	tags->>'historic' AS historic,
+	tags->>'horse' AS horse,
+	tags->>'junction' AS junction,
+	tags->>'landuse' AS landuse,
+	tags->>'layer' AS layer,
+	tags->>'leisure' AS leisure,
+	tags->>'lock' AS lock,
+	tags->>'man_made' AS man_made,
+	tags->>'military' AS military,
+	tags->>'name' AS name,
+	tags->>'natural' AS "natural",
+	tags->>'oneway' AS oneway,
+	tags->>'place' AS place,
+	tags->>'power' AS power,
+	tags->>'railway' AS railway,
+	tags->>'ref' AS ref,
+	tags->>'religion' AS religion,
+	tags->>'route' AS route,
+	tags->>'service' AS service,
+	tags->>'shop' AS shop,
+	tags->>'surface' AS surface,
+	tags->>'tourism' AS tourism,
+	tags->>'tracktype' AS tracktype,
+	tags->>'tunnel' AS tunnel,
+	tags->>'water' AS water,
+	tags->>'waterway' AS waterway,
+	null as way_area,
+	null as z_order,
+	(SELECT hstore(array_agg(key), array_agg(value)) FROM jsonb_each_text(tags))::hstore AS tags,
+	geom AS way
+	FROM postpass_line;
+
+CREATE OR REPLACE VIEW planet_osm_polygon AS SELECT
+	CASE WHEN osm_type = 'R' THEN -osm_id ELSE osm_id END as osm_id,
+	tags->>'access' AS access,
+	tags->>'addr:housename' AS "addr:housename",
+	tags->>'addr:housenumber' AS "addr:housenumber",
+	tags->>'addr:interpolation' AS "addr:interpolation",
+	tags->>'admin_level' AS admin_level,
+	tags->>'aerialway' AS aerialway,
+	tags->>'aeroway' AS aeroway,
+	tags->>'amenity' AS amenity,
+	tags->>'barrier' AS barrier,
+	tags->>'bicycle' AS bicycle,
+	tags->>'bridge' AS bridge,
+	tags->>'boundary' AS boundary,
+	tags->>'building' AS building,
+	tags->>'construction' AS construction,
+	tags->>'covered' AS covered,
+	tags->>'foot' AS foot,
+	tags->>'highway' AS highway,
+	tags->>'historic' AS historic,
+	tags->>'horse' AS horse,
+	tags->>'junction' AS junction,
+	tags->>'landuse' AS landuse,
+	tags->>'layer' AS layer,
+	tags->>'leisure' AS leisure,
+	tags->>'lock' AS lock,
+	tags->>'man_made' AS man_made,
+	tags->>'military' AS military,
+	tags->>'name' AS name,
+	tags->>'natural' AS "natural",
+	tags->>'oneway' AS oneway,
+	tags->>'place' AS place,
+	tags->>'power' AS power,
+	tags->>'railway' AS railway,
+	tags->>'ref' AS ref,
+	tags->>'religion' AS religion,
+	tags->>'route' AS route,
+	tags->>'service' AS service,
+	tags->>'shop' AS shop,
+	tags->>'surface' AS surface,
+	tags->>'tourism' AS tourism,
+	tags->>'tracktype' AS tracktype,
+	tags->>'tunnel' AS tunnel,
+	tags->>'water' AS water,
+	tags->>'waterway' AS waterway,
+	(SELECT hstore(array_agg(key), array_agg(value)) FROM jsonb_each_text(tags))::hstore AS tags,
+	geom AS way
+	FROM postpass_polygon;
+

--- a/views.sql
+++ b/views.sql
@@ -1,21 +1,26 @@
 -- Combined views
 
 CREATE OR REPLACE VIEW postpass_pointlinepolygon AS
-	SELECT * FROM postpass_point
-	UNION ALL SELECT * FROM postpass_line
-	UNION ALL SELECT * FROM postpass_polygon;
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, NULL::float as area_m2 FROM postpass_point
+	UNION ALL
+	SELECT osm_type, osm_id, tags, geom, length_m, NULL::float as area_m2 FROM postpass_line
+	UNION ALL
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, area_m2 FROM postpass_polygon;
 
 CREATE OR REPLACE VIEW postpass_pointpolygon AS
-	SELECT * FROM postpass_point
-	UNION ALL SELECT * FROM postpass_polygon;
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, NULL::float as area_m2 FROM postpass_point
+	UNION ALL
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, area_m2 FROM postpass_polygon;
 
 CREATE OR REPLACE VIEW postpass_pointline AS
-	SELECT * FROM postpass_point
-	UNION ALL SELECT * FROM postpass_line;
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, NULL::float as area_m2 FROM postpass_point
+	UNION ALL
+	SELECT osm_type, osm_id, tags, geom, length_m, NULL::float as area_m2 FROM postpass_line;
 
 CREATE OR REPLACE VIEW postpass_linepolygon AS
-	SELECT * FROM postpass_line
-	UNION ALL SELECT * FROM postpass_polygon;
+	SELECT osm_type, osm_id, tags, geom, length_m, NULL::float as area_m2 FROM postpass_line
+	UNION ALL
+	SELECT osm_type, osm_id, tags, geom, NULL::float as length_m, area_m2 FROM postpass_polygon;
 
 
 -- Compatibility Views for backwards compatibility with postpass 0.1


### PR DESCRIPTION
This adds a `length_m` & `area_m2` column to appropriate tables (& views), with the length & area calculated by PostgreSQL on spheroid. There is also an index.

This makes it easier to make area or length based queries with Postpass. It's not possible to do this with Overpass. The pre-calculation & indexing will make this perform properly.


This PR is based off #30 